### PR TITLE
Correct path on windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,12 @@
       "devDependencies": {
         "@as-pect/cli": "^7.0.7",
         "@assemblyscript/loader": "^0.21.2",
+        "@envy-as/cli": "https://github.com/jtenner/envy",
         "@typescript-eslint/eslint-plugin": "^5.18.0",
         "@typescript-eslint/parser": "^5.18.0",
+        "as-big": "^0.2.0",
         "as-console": "^6.0.2",
+        "as-wasi": "^0.5.1",
         "assemblyscript": "^0.21.2",
         "eslint": "^8.12.0",
         "eslint-config-google": "^0.14.0",
@@ -157,6 +160,16 @@
       "integrity": "sha512-vBjwP1Zex68r0x9ffBl1p8R8ihf9FTQkhrwbK+IoLYyTmla1ghwwrKVuBfjmt4rGA44xSss9z7ATNCAjJHaedA==",
       "dev": true
     },
+    "node_modules/@assemblyscript/wasi-shim": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/wasi-shim/-/wasi-shim-0.1.0.tgz",
+      "integrity": "sha512-fSLH7MdJHf2uDW5llA5VCF/CG62Jp2WkYGui9/3vIWs3jDhViGeQF7nMYLUjpigluM5fnq61I6obtCETy39FZw==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/assemblyscript"
+      }
+    },
     "node_modules/@chevrotain/cst-dts-gen": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.3.0.tgz",
@@ -189,6 +202,60 @@
       "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.3.0.tgz",
       "integrity": "sha512-KCpFcX+kNyKlVZQW60ZUGRW5Nsg5u0F2CIgHiDQyg282ouHS9xap2ZEKqhwGE/0nYP46nAPnGPdb/IYh7ZHOsA==",
       "dev": true
+    },
+    "node_modules/@envy-as/cli": {
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/jtenner/envy.git#be2c4bd07e3e44f5e31b1fc473de319e46dd8f5c",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "arg": "^5.0.1",
+        "glob": "^7.2.0",
+        "glob-promise": "^4.2.2",
+        "kleur": "^4.1.4"
+      },
+      "bin": {
+        "envy": "bin/envy.js"
+      }
+    },
+    "node_modules/@envy-as/cli/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@envy-as/cli/node_modules/glob-promise": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-4.2.2.tgz",
+      "integrity": "sha512-xcUzJ8NWN5bktoTIX7eOclO1Npxd/dyVqUJxlLIDasT4C7KZyqlPIwkdJ0Ypiy3p2ZKahTjK4M9uC3sNSfNMzw==",
+      "dev": true,
+      "dependencies": {
+        "@types/glob": "^7.1.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/ahmadnassri"
+      },
+      "peerDependencies": {
+        "glob": "^7.1.6"
+      }
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.2",
@@ -565,6 +632,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -580,11 +653,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/as-big": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/as-big/-/as-big-0.2.0.tgz",
+      "integrity": "sha512-Stfxo9O3g/ZHAjRCGqDhkB1yn2iEaddHlzT0iYnZ2JwZ8HtDXwRqt2f7lORPry9v3yb5lGsJNh1HZNxiXMTSEw==",
+      "dev": true
+    },
     "node_modules/as-console": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/as-console/-/as-console-6.0.2.tgz",
       "integrity": "sha512-prs5zKPSlpdWjmDNB5rWtyZhtBWOvi12QVwK3cMdJWm/0BTCpoF60Q31Sbaa2igfktyyiShDSNoInRjIEXoqSg==",
       "dev": true
+    },
+    "node_modules/as-wasi": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/as-wasi/-/as-wasi-0.5.1.tgz",
+      "integrity": "sha512-urJEqJgxkz7YQv107wGp5qDorg1eCUf1tKruL1XYLgwI3+TLULMhWkoJ1Mwtz4zMtC/zc5LsrmCCmcVM4VNteg==",
+      "dev": true,
+      "dependencies": {
+        "@assemblyscript/wasi-shim": "^0.1"
+      }
     },
     "node_modules/assemblyscript": {
       "version": "0.21.3",
@@ -1515,6 +1603,15 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2414,6 +2511,12 @@
       "integrity": "sha512-vBjwP1Zex68r0x9ffBl1p8R8ihf9FTQkhrwbK+IoLYyTmla1ghwwrKVuBfjmt4rGA44xSss9z7ATNCAjJHaedA==",
       "dev": true
     },
+    "@assemblyscript/wasi-shim": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/wasi-shim/-/wasi-shim-0.1.0.tgz",
+      "integrity": "sha512-fSLH7MdJHf2uDW5llA5VCF/CG62Jp2WkYGui9/3vIWs3jDhViGeQF7nMYLUjpigluM5fnq61I6obtCETy39FZw==",
+      "dev": true
+    },
     "@chevrotain/cst-dts-gen": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.3.0.tgz",
@@ -2446,6 +2549,42 @@
       "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.3.0.tgz",
       "integrity": "sha512-KCpFcX+kNyKlVZQW60ZUGRW5Nsg5u0F2CIgHiDQyg282ouHS9xap2ZEKqhwGE/0nYP46nAPnGPdb/IYh7ZHOsA==",
       "dev": true
+    },
+    "@envy-as/cli": {
+      "version": "git+ssh://git@github.com/jtenner/envy.git#be2c4bd07e3e44f5e31b1fc473de319e46dd8f5c",
+      "dev": true,
+      "from": "@envy-as/cli@https://github.com/jtenner/envy",
+      "requires": {
+        "arg": "^5.0.1",
+        "glob": "^7.2.0",
+        "glob-promise": "^4.2.2",
+        "kleur": "^4.1.4"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "glob-promise": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-4.2.2.tgz",
+          "integrity": "sha512-xcUzJ8NWN5bktoTIX7eOclO1Npxd/dyVqUJxlLIDasT4C7KZyqlPIwkdJ0Ypiy3p2ZKahTjK4M9uC3sNSfNMzw==",
+          "dev": true,
+          "requires": {
+            "@types/glob": "^7.1.3"
+          }
+        }
+      }
     },
     "@eslint/eslintrc": {
       "version": "1.3.2",
@@ -2683,6 +2822,12 @@
         "color-convert": "^2.0.1"
       }
     },
+    "arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true
+    },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2695,11 +2840,26 @@
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
+    "as-big": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/as-big/-/as-big-0.2.0.tgz",
+      "integrity": "sha512-Stfxo9O3g/ZHAjRCGqDhkB1yn2iEaddHlzT0iYnZ2JwZ8HtDXwRqt2f7lORPry9v3yb5lGsJNh1HZNxiXMTSEw==",
+      "dev": true
+    },
     "as-console": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/as-console/-/as-console-6.0.2.tgz",
       "integrity": "sha512-prs5zKPSlpdWjmDNB5rWtyZhtBWOvi12QVwK3cMdJWm/0BTCpoF60Q31Sbaa2igfktyyiShDSNoInRjIEXoqSg==",
       "dev": true
+    },
+    "as-wasi": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/as-wasi/-/as-wasi-0.5.1.tgz",
+      "integrity": "sha512-urJEqJgxkz7YQv107wGp5qDorg1eCUf1tKruL1XYLgwI3+TLULMhWkoJ1Mwtz4zMtC/zc5LsrmCCmcVM4VNteg==",
+      "dev": true,
+      "requires": {
+        "@assemblyscript/wasi-shim": "^0.1"
+      }
     },
     "assemblyscript": {
       "version": "0.21.3",
@@ -3394,6 +3554,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
+    },
+    "kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "dev": true
     },
     "levn": {

--- a/tester/lib/cli.js
+++ b/tester/lib/cli.js
@@ -6,12 +6,12 @@ import glob from 'glob-promise';
 import asc from 'assemblyscript/dist/asc.js';
 import {WASI} from 'wasi';
 import fs, {promises as asyncfs} from 'fs';
+import {fileURLToPath} from 'node:url';
 
 const SIZE_OFFSET = -4;
 const parsed = new URL(import.meta.url);
-const filePath = path.resolve(parsed.pathname);// .slice(1));
+const filePath = path.resolve(fileURLToPath(parsed));
 const fileDir = path.dirname(filePath);
-console.log(fileDir);
 const assemblyEntry = path.join(fileDir, '../assembly/unittest.ts');
 const cwd = process.cwd();
 

--- a/tester/tester.js
+++ b/tester/tester.js
@@ -4,11 +4,13 @@ import { URL } from 'url';
 import path from 'path';
 import { performance } from 'perf_hooks';
 import { green } from 'kleur/colors';
+import { fileURLToPath } from 'node:url';
 
 const binLocation = import.meta.url;
 const parsedBinLocation = new URL(binLocation);
-const binFileLocation = parsedBinLocation.pathname;// .slice(1);
-const libFileLocation = path.join(binFileLocation, '../lib/bootstrap.js');
+const binFileURL = parsedBinLocation.href;
+const fileDir = path.dirname(fileURLToPath(binFileURL));
+const libFileLocation = path.join(fileDir, '/lib/bootstrap.js');
 
 const args = [
   '--experimental-wasi-unstable-preview1',


### PR DESCRIPTION
On Windows, the tester cli fails to run ( yarn asctester ) because it cannot find the :

bootstrap.js
unitttest.ts
The error displays that paths of both file are something like :
C:\Users\maxim\projetsInfo\Blockchain\Massa\jj\node_modules\tester\lib\bootstrap.js
Error: Cannot find module 'C:\C:\Users\maxim\projetsInfo\Blockchain\Massa\jj\node_modules\tester\lib\bootstrap.js'

Working well on Mac, not tested on Linux.