### PR TITLE
improve exports

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+export * from "./assembly";


### PR DESCRIPTION
# Issue

Before: we import classes this way: 

```
import {Currency, Amount} from '@massalabs/as/assembly';
```

Doing 

```
import {Currency, Amount} from '@massalabs/as';
```

causes an error.

# Solution

With this PR, we will be able to do 

```
import {Currency, Amount} from '@massalabs/as';
```