### PR TITLE
CD: disable fast fail

### DIFF
--- a/.github/workflows/npm-publish-dev.yml
+++ b/.github/workflows/npm-publish-dev.yml
@@ -13,6 +13,7 @@ jobs:
 
   publish-npm:
     strategy:
+      fail-fast: false
       matrix:
         sub-package: ["as", "tester", "transformer"]
     needs: test

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,6 +13,7 @@ jobs:
 
   publish-npm:
     strategy:
+      fail-fast: false
       matrix:
         sub-package: ["as", "tester", "transformer"]
     needs: test


### PR DESCRIPTION
When using matrix in GitHub Actions, default behavior is to cancel all jobs of the matrix as soon as one job in this matrix fails. Here we don not want to cancel the other jobs when a npm package fails to publish: we want other packages to be published. This will allow us to publish only on npm package at a time: 

1. bump the version on the package you want to publish 
2. create a new release in this repository
3. workflow will trigger and publish your new version
4. but jobs for other packages you did not bump a new version will fail, this is intended.

We might find a better way latter but for now it's good enough.