### PR TITLE
Fix transformer replace double quotes

### DIFF
--- a/transformer/src/transformers/testTable.ts
+++ b/transformer/src/transformers/testTable.ts
@@ -83,8 +83,8 @@ export class TestTable {
 
       const test = TestTable.generateTest(
         testCounter.toString(), // use test counter as test name
-        gotExpr.replace(/['`]/g, ''),
-        expectExpr.replace(/['`]/g, ''),
+        gotExpr.replace(/['`"]/g, ''),
+        expectExpr.replace(/['`"]/g, ''),
         ifExpr,
         needWant,
       );


### PR DESCRIPTION
Thanks to this PR we can write test with double quotes: 

```
  checksForEachLineThatThe("`greater than` of two integers", "arg0 > arg1", isFalse, [
    0, 1,
    2, 3,
  ]);
```