### PR TITLE
fix(as-proba): renamed randomInt to unsafeBoundedRandom

### DIFF
--- a/packages/as-proba/assembly/__tests__/random.spec.ts
+++ b/packages/as-proba/assembly/__tests__/random.spec.ts
@@ -1,4 +1,4 @@
-import { randomInt } from '../probability/random';
+import { unsafeBoundedRandom } from '../probability/random';
 import { drawHistogram } from './helper';
 
 describe('Doc test', () => {
@@ -7,7 +7,7 @@ describe('Doc test', () => {
     const upperLimit = 5;
 
     for (let i = 0; i < 5; i++) {
-      const s = randomInt(lowerLimit, upperLimit);
+      const s = unsafeBoundedRandom(lowerLimit, upperLimit);
 
       expect<u64>(s).toBeGreaterThanOrEqual(0);
       expect<u64>(s).toBeLessThanOrEqual(5);
@@ -24,7 +24,7 @@ describe('Blackbox test', () => {
     }
 
     for (let i = 0; i < 1000000; i++) {
-      a[i32(randomInt(0, 40))] += 1;
+      a[i32(unsafeBoundedRandom(0, 40))] += 1;
     }
 
     drawHistogram(a, 160);

--- a/packages/as-proba/assembly/probability/random.ts
+++ b/packages/as-proba/assembly/probability/random.ts
@@ -10,6 +10,6 @@
  * @returns an unsafe random integer between given limits.
  *
  */
-export function randomInt(ll: u64, ul: u64): u64 {
+export function unsafeBoundedRandom(ll: u64, ul: u64): u64 {
   return ll + u64(Math.round(f64(ul - ll) * Math.random()));
 }

--- a/packages/as-proba/assembly/probability/sampler.ts
+++ b/packages/as-proba/assembly/probability/sampler.ts
@@ -1,4 +1,4 @@
-import { randomInt } from './random';
+import { unsafeBoundedRandom } from './random';
 
 /**
  * This module exports a class named Sampler that allows the generation of observations based on a
@@ -111,7 +111,7 @@ export class Sampler {
    */
   rejectionSampling(n: u64, max: f32): u64 {
     while (true) {
-      const k = randomInt(0, n - 1);
+      const k = unsafeBoundedRandom(0, n - 1);
       const x = Math.random() * max;
       if (x <= this.probability(k)) {
         return k;


### PR DESCRIPTION
Aim's to resolve #213 from #205.

Choosed to call this function 'unsafeBoundedRandom' since there already is an 'unsafeRandom' method (which is not bounded at all).