### PR TITLE
Docs: removed 'developpment guide' from readmes

### DIFF
--- a/packages/as-types/README.md
+++ b/packages/as-types/README.md
@@ -38,32 +38,6 @@ Packages are independant you can choose to install what you need
 npm i --save-dev @massalabs/as-types
 ```
 
-## Development guide
-
-### Build
-
-```plain
-npm run build
-```
-
-### Code linting and formatting
-
-```plain
-npm run fmt
-```
-
-### Test
-
-```plain
-npm run test
-```
-
-### Generate doc
-From the root folder :
-```plain
-npm run doc
-```
-
 ## Usage
 After installing *as-types*, you can import the object classes and functions that you need in your AssemblyScript file.
 


### PR DESCRIPTION
Aim's to resolve #217 from meta #205.