### PR TITLE
move as-bignum dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@massalabs/massa-as-sdk": "^2.0.1",
         "@massalabs/prettier-config-as": "^0.0.2",
         "@types/debug": "^4.1.8",
-        "as-bignum": "^0.2.31",
         "as-proto": "^1.3.0",
         "as-proto-gen": "^1.3.0",
         "husky": "^8.0.2",
@@ -2200,8 +2199,7 @@
     "node_modules/as-bignum": {
       "version": "0.2.31",
       "resolved": "https://registry.npmjs.org/as-bignum/-/as-bignum-0.2.31.tgz",
-      "integrity": "sha512-4DRQ9pHu8BCfse4xvZucg5t7mkDtiM93dBzZkXpcpAJ2fmf+p/wbYxN24nCvRVACRPavPYreea5k3ugWD1C3Fg==",
-      "dev": true
+      "integrity": "sha512-4DRQ9pHu8BCfse4xvZucg5t7mkDtiM93dBzZkXpcpAJ2fmf+p/wbYxN24nCvRVACRPavPYreea5k3ugWD1C3Fg=="
     },
     "node_modules/as-proto": {
       "version": "1.3.0",
@@ -6765,6 +6763,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "as-bignum": "^0.2.31",
         "assemblyscript": "^0.25.0"
       }
     },
@@ -7886,6 +7885,7 @@
     "@massalabs/as-types": {
       "version": "file:packages/as-types",
       "requires": {
+        "as-bignum": "^0.2.31",
         "assemblyscript": "^0.25.0"
       }
     },
@@ -8431,8 +8431,7 @@
     "as-bignum": {
       "version": "0.2.31",
       "resolved": "https://registry.npmjs.org/as-bignum/-/as-bignum-0.2.31.tgz",
-      "integrity": "sha512-4DRQ9pHu8BCfse4xvZucg5t7mkDtiM93dBzZkXpcpAJ2fmf+p/wbYxN24nCvRVACRPavPYreea5k3ugWD1C3Fg==",
-      "dev": true
+      "integrity": "sha512-4DRQ9pHu8BCfse4xvZucg5t7mkDtiM93dBzZkXpcpAJ2fmf+p/wbYxN24nCvRVACRPavPYreea5k3ugWD1C3Fg=="
     },
     "as-proto": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@massalabs/massa-as-sdk": "^2.0.1",
     "@massalabs/prettier-config-as": "^0.0.2",
     "@types/debug": "^4.1.8",
-    "as-bignum": "^0.2.31",
     "as-proto": "^1.3.0",
     "as-proto-gen": "^1.3.0",
     "husky": "^8.0.2",

--- a/packages/as-types/package.json
+++ b/packages/as-types/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "as-bignum": "^0.2.31",
     "assemblyscript": "^0.25.0"
   },
   "files": [


### PR DESCRIPTION
as-bignum package must be in @massalabs/as-types depedencies to be installed when one install this package