### PR TITLE
add limitation

### DIFF
--- a/packages/as-transformer/README.md
+++ b/packages/as-transformer/README.md
@@ -79,6 +79,9 @@ export function sayHello(args: StaticArray<u8>) : StaticArray<u8> {
 At the moment only the smart contract main file can use this transformer.
 Any functions outside this file, that are imported and re-exported can not use this decorator.
 
+⚠️ @massaExport cannot be used with the constructor function.
+This is because the deployer uses "Args" to interact with functions during deployment. This problem should be solved soon.
+
 
 ## Contributing
 We welcome contributions from the community!


### PR DESCRIPTION
Task Overview
add on Readme of as-transformer a "limitation" section.

Description
We can use "@massaExport" in some functions. But this decorator doesn't work with the constructor of a smart contract.
We must add a "limitation" section to explain that.