### PR TITLE
Fix: 'Compilation failed: Cannot read properties of undefined (readin…

### DIFF
--- a/packages/as-transformer/src/transformers/massaExport.ts
+++ b/packages/as-transformer/src/transformers/massaExport.ts
@@ -60,7 +60,9 @@ export class MassaExport {
   isMatching(node: MassaFunctionNode): boolean {
     const toMatch =
       this.updates.filter(
-        (update) => update.getData().get('funcToPrivate')![0] === node.name,
+        (update) =>
+          update.getContentType() == UpdateType.FunctionDeclaration &&
+          update.getData().get('funcToPrivate')![0] === node.name,
       ).length <= 0 && hasDecorator(node.node!, 'massaExport');
     const alreadyDone =
       GlobalUpdates.get().filter(


### PR DESCRIPTION
…g '0')' that appears when exporting many functions (one using u128)
fix #297 

Sadly it reveals #298 and can't be fully tested because of #296 but seems to be ok