### PR TITLE
Add next generic to args

### DIFF
--- a/packages/as-types/assembly/__tests__/argument.spec.ts
+++ b/packages/as-types/assembly/__tests__/argument.spec.ts
@@ -492,7 +492,7 @@ describe('Args tests', () => {
     const args = new Args(
       new Args().addSerializableObjectArray(arrayOfSerializable).serialize(),
     );
-    const deser = args.nextSerializableObjectArray<Divinity>().unwrap();
+    const deser = args.next<Array<Divinity>, Divinity>().unwrap();
     const first = deser[0];
     expect(deser).toHaveLength(2);
     expect(first.age).toBe(14);

--- a/packages/as-types/assembly/__tests__/argument.spec.ts
+++ b/packages/as-types/assembly/__tests__/argument.spec.ts
@@ -492,7 +492,7 @@ describe('Args tests', () => {
     const args = new Args(
       new Args().addSerializableObjectArray(arrayOfSerializable).serialize(),
     );
-    const deser = args.next<Array<Divinity>, Divinity>().unwrap();
+    const deser = args.nextSerializableObjectArray<Divinity>().unwrap();
     const first = deser[0];
     expect(deser).toHaveLength(2);
     expect(first.age).toBe(14);
@@ -717,19 +717,50 @@ describe('Args next<T>', () => {
     expect(person2.name).toBe(name);
   });
 
-  // it ('handles SerializableObjectArray', () => {
-  //   const arrayOfSerializable = [
-  //     new Divinity(42, 'Batman'),
-  //     new Divinity(84, 'Superman'),
-  //   ];
-  //   const args = new Args(
-  //     new Args().addSerializableObjectArray(arrayOfSerializable).serialize(),
-  //   );
-  //   const deser = args.next<Array<Divinity>>().unwrap();
-  //   expect(deser).toHaveLength(2);
-  //   expect(deser[0].age).toBe(42);
-  //   expect(deser[0].name).toBe('Batman');
-  //   expect(deser[1].age).toBe(84);
-  //   expect(deser[1].name).toBe('Superman');
-  // });
+  it('handles SerializableObjectArray', () => {
+    const arrayOfSerializable = [
+      new Divinity(42, 'Batman'),
+      new Divinity(84, 'Superman'),
+    ];
+    const args = new Args(
+      new Args().addSerializableObjectArray(arrayOfSerializable).serialize(),
+    );
+    const deser = args.next<Array<Divinity>, Divinity>().unwrap();
+    expect(deser).toHaveLength(2);
+    expect(deser[0].age).toBe(42);
+    expect(deser[0].name).toBe('Batman');
+    expect(deser[1].age).toBe(84);
+    expect(deser[1].name).toBe('Superman');
+  });
+
+  it('handles SerializableObjectArray with empty array', () => {
+    const emptyArray: Divinity[] = [];
+    const args = new Args(
+      new Args().addSerializableObjectArray(emptyArray).serialize(),
+    );
+    expect(args.next<Array<Divinity>, Divinity>().unwrap()).toStrictEqual(
+      emptyArray,
+    );
+  });
+
+  it('handles StringArray and SerializableObjectArray', () => {
+    const arrayOfStrings = ['hello', 'world'];
+    const arrayOfSerializable = [
+      new Divinity(42, 'Batman'),
+      new Divinity(84, 'Superman'),
+    ];
+
+    const args = new Args(
+      new Args()
+        .add(arrayOfStrings)
+        .addSerializableObjectArray(arrayOfSerializable)
+        .serialize(),
+    );
+
+    const strings = args.next<Array<string>>().unwrap();
+    expect(strings).toStrictEqual(arrayOfStrings);
+
+    const deserialized = args.next<Array<Divinity>, Divinity>().unwrap();
+    expect(deserialized).toStrictEqual(arrayOfSerializable);
+  });
 });

--- a/packages/as-types/assembly/__tests__/argument.spec.ts
+++ b/packages/as-types/assembly/__tests__/argument.spec.ts
@@ -501,3 +501,235 @@ describe('Args tests', () => {
     expect(deser[1].name).toBe('Superman');
   });
 });
+
+describe('Args next<T>', () => {
+  it('handles u8', () => {
+    const args = new Args(new Args().add(1 as u8).serialize());
+    expect(args.next<u8>().unwrap()).toBe(1);
+  });
+
+  it('handles u16', () => {
+    const args = new Args(new Args().add(2 as u16).serialize());
+    expect(args.next<u16>().unwrap()).toBe(2);
+  });
+
+  it('handles u32', () => {
+    const args = new Args(new Args().add(3 as u32).serialize());
+    expect(args.next<u32>().unwrap()).toBe(3);
+  });
+
+  it('handles u64', () => {
+    const args = new Args(new Args().add(4 as u64).serialize());
+    expect(args.next<u64>().unwrap()).toBe(4);
+  });
+
+  it('handles i16', () => {
+    const args = new Args(new Args().add(-5 as i16).serialize());
+    expect(args.next<i16>().unwrap()).toBe(-5);
+  });
+
+  it('handles i32', () => {
+    const args = new Args(new Args().add(-6 as i32).serialize());
+    expect(args.next<i32>().unwrap()).toBe(-6);
+  });
+
+  it('handles i64', () => {
+    const args = new Args(new Args().add(-7 as i64).serialize());
+    expect(args.next<i64>().unwrap()).toBe(-7);
+  });
+
+  it('handles f32', () => {
+    const args = new Args(new Args().add(8.8 as f32).serialize());
+    expect(args.next<f32>().unwrap()).toBe(8.8);
+  });
+
+  it('handles f64', () => {
+    const args = new Args(new Args().add(9.9 as f64).serialize());
+    expect(args.next<f64>().unwrap()).toBe(9.9);
+  });
+
+  it('handles bool', () => {
+    const args = new Args(new Args().add(true).serialize());
+    expect(args.next<bool>().unwrap()).toBe(true);
+  });
+
+  it('handles u128', () => {
+    const args = new Args(new Args().add(u128.Max).serialize());
+    expect(args.next<u128>().unwrap()).toBe(u128.Max);
+  });
+
+  it('handles i128', () => {
+    const args = new Args(new Args().add(i128.Max).serialize());
+    expect(args.next<i128>().unwrap()).toBe(i128.Max);
+  });
+
+  it('handles u256', () => {
+    const args = new Args(new Args().add(u256.Max).serialize());
+    expect(args.next<u256>().unwrap()).toBe(u256.Max);
+  });
+
+  it('handles string', () => {
+    const args = new Args(new Args().add('hello').serialize());
+    expect(args.next<string>().unwrap()).toBe('hello');
+  });
+
+  it('handles Uint8Array', () => {
+    const array = new Uint8Array(2);
+    array.set([65, 88]);
+    const args = new Args(new Args().add(array).serialize());
+    expect(args.next<Uint8Array>().unwrap()).toStrictEqual(array);
+  });
+
+  it('handles StaticArray<u8>', () => {
+    const array = new StaticArray<u8>(2);
+    array[0] = 65;
+    array[1] = 88;
+    const args = new Args(new Args().add(array).serialize());
+    const resultArray = args.next<StaticArray<u8>>().unwrap();
+    expect(resultArray.length).toBe(array.length);
+    expect(resultArray[0]).toBe(array[0]);
+    expect(resultArray[1]).toBe(array[1]);
+  });
+
+  it('handles Array<u8>', () => {
+    const array = [65, 88] as u8[];
+    const args = new Args(new Args().add(array).serialize());
+    const resultArray = args.next<Array<u8>>().unwrap();
+    expect(resultArray.length).toBe(array.length);
+    expect(resultArray[0]).toBe(array[0]);
+    expect(resultArray[1]).toBe(array[1]);
+  });
+
+  it('handles Array<i32>', () => {
+    const array = [65, 88] as i32[];
+    const args = new Args(new Args().add(array).serialize());
+    const resultArray = args.next<Array<i32>>().unwrap();
+    expect(resultArray.length).toBe(array.length);
+    expect(resultArray[0]).toBe(array[0]);
+    expect(resultArray[1]).toBe(array[1]);
+  });
+
+  it('handles Array<i128>', () => {
+    const array = [i128.from(65), i128.from(88)];
+    const args = new Args(new Args().add(array).serialize());
+    const resultArray = args.next<Array<i128>>().unwrap();
+    expect(resultArray.length).toBe(array.length);
+    expect<i128>(resultArray[0]).toBe(array[0]);
+    expect<i128>(resultArray[1]).toBe(array[1]);
+  });
+
+  it('handles Array<u128>', () => {
+    const array = [u128.from(65), u128.from(88)];
+    const args = new Args(new Args().add(array).serialize());
+    const resultArray = args.next<Array<u128>>().unwrap();
+    expect(resultArray.length).toBe(array.length);
+    expect<u128>(resultArray[0]).toBe(array[0]);
+    expect<u128>(resultArray[1]).toBe(array[1]);
+  });
+
+  it('handles Array<u256>', () => {
+    const array = [u256.from(65), u256.from(88)];
+    const args = new Args(new Args().add(array).serialize());
+    const resultArray = args.next<Array<u256>>().unwrap();
+    expect(resultArray.length).toBe(array.length);
+    expect<u256>(resultArray[0]).toBe(array[0]);
+    expect<u256>(resultArray[1]).toBe(array[1]);
+  });
+
+  it('handles Array<f32>', () => {
+    const array = [65.5, 88.8] as f32[];
+    const args = new Args(new Args().add(array).serialize());
+    const resultArray = args.next<Array<f32>>().unwrap();
+    expect(resultArray.length).toBe(array.length);
+    expect(resultArray[0]).toBe(array[0]);
+    expect(resultArray[1]).toBe(array[1]);
+  });
+
+  it('handles Array<f64>', () => {
+    const array = [65.5, 88.8] as f64[];
+    const args = new Args(new Args().add(array).serialize());
+    const resultArray = args.next<Array<f64>>().unwrap();
+    expect(resultArray.length).toBe(array.length);
+    expect(resultArray[0]).toBe(array[0]);
+    expect(resultArray[1]).toBe(array[1]);
+  });
+
+  it('handles Array<bool>', () => {
+    const array = [true, false];
+    const args = new Args(new Args().add(array).serialize());
+    const resultArray = args.next<Array<bool>>().unwrap();
+    expect(resultArray.length).toBe(array.length);
+    expect(resultArray[0]).toBe(array[0]);
+    expect(resultArray[1]).toBe(array[1]);
+  });
+
+  it('handles Array<string>', () => {
+    const array = ['hello', 'world'];
+    const args = new Args(new Args().add(array).serialize());
+    const resultArray = args.next<Array<string>>().unwrap();
+    expect(resultArray.length).toBe(array.length);
+    expect(resultArray[0]).toBe(array[0]);
+    expect(resultArray[1]).toBe(array[1]);
+  });
+
+  it('handles multiple types', () => {
+    const args = new Args(
+      new Args()
+        .add(1 as u8)
+        .add(2 as u16)
+        .add(3 as u32)
+        .add(4 as u64)
+        .add(-5 as i16)
+        .add(-6 as i32)
+        .add(-7 as i64)
+        .add(8.8 as f32)
+        .add(9.9 as f64)
+        .add(true)
+        .add(u128.Max)
+        .add(i128.Max)
+        .add(u256.Max)
+        .add('hello')
+        .serialize(),
+    );
+    expect(args.next<u8>().unwrap()).toBe(1);
+    expect(args.next<u16>().unwrap()).toBe(2);
+    expect(args.next<u32>().unwrap()).toBe(3);
+    expect(args.next<u64>().unwrap()).toBe(4);
+    expect(args.next<i16>().unwrap()).toBe(-5);
+    expect(args.next<i32>().unwrap()).toBe(-6);
+    expect(args.next<i64>().unwrap()).toBe(-7);
+    expect(args.next<f32>().unwrap()).toBe(8.8);
+    expect(args.next<f64>().unwrap()).toBe(9.9);
+    expect(args.next<bool>().unwrap()).toBe(true);
+    expect(args.next<u128>().unwrap()).toBe(u128.Max);
+    expect(args.next<i128>().unwrap()).toBe(i128.Max);
+    expect(args.next<u256>().unwrap()).toBe(u256.Max);
+    expect(args.next<string>().unwrap()).toBe('hello');
+  });
+
+  it('handles Serializable', () => {
+    const age = 42 as i32;
+    const name = 'Wolverine';
+    const person = new Divinity(age, name);
+    const args = new Args(new Args().add(person).serialize());
+    const person2 = args.next<Divinity>().unwrap();
+    expect(person2.age).toBe(age);
+    expect(person2.name).toBe(name);
+  });
+
+  // it ('handles SerializableObjectArray', () => {
+  //   const arrayOfSerializable = [
+  //     new Divinity(42, 'Batman'),
+  //     new Divinity(84, 'Superman'),
+  //   ];
+  //   const args = new Args(
+  //     new Args().addSerializableObjectArray(arrayOfSerializable).serialize(),
+  //   );
+  //   const deser = args.next<Array<Divinity>>().unwrap();
+  //   expect(deser).toHaveLength(2);
+  //   expect(deser[0].age).toBe(42);
+  //   expect(deser[0].name).toBe('Batman');
+  //   expect(deser[1].age).toBe(84);
+  //   expect(deser[1].name).toBe('Superman');
+  // });
+});

--- a/packages/as-types/assembly/__tests__/argument.spec.ts
+++ b/packages/as-types/assembly/__tests__/argument.spec.ts
@@ -101,6 +101,19 @@ describe('Args tests', () => {
     expect(args2.nextU64().unwrap()).toBe(113);
   });
 
+  it('With i128', () => {
+    const val1 = i128.Max;
+    const val2 = i128.add(i128.fromU64(U64.MAX_VALUE), i128.fromU64(1));
+    const val3 = i128.Zero;
+
+    const serialized = new Args().add(val1).add(val2).add(val3).serialize();
+
+    const args = new Args(serialized);
+    expect(args.nextI128().unwrap()).toBe(val1);
+    expect(args.nextI128().unwrap()).toBe(val2);
+    expect(args.nextI128().unwrap()).toBe(val3);
+  });
+
   it('With u128', () => {
     const val1 = u128.Max;
     const val2 = u128.add(u128.fromU64(U64.MAX_VALUE), u128.fromU64(1));

--- a/packages/as-types/assembly/argument.ts
+++ b/packages/as-types/assembly/argument.ts
@@ -317,15 +317,15 @@ export class Args {
 
   /**
    * Deserializes an I128 from a serialized array starting from the current offset.
-   * 
+   *
    * @remarks
    * If the deserialization failed, it returns a Result containing 0 and an error message:
    * "can't deserialize i128 from given argument: out of range".
-   * 
+   *
    * @returns a Result object:
    * - Containing the next deserialized I128 starting from the current offset
    * - Containing 0 and an error message if the deserialization failed
-   * 
+   *
    */
   nextI128(): Result<i128> {
     const size: i32 = 16;
@@ -617,6 +617,100 @@ export class Args {
     );
     this._offset += size;
     return data;
+  }
+
+  /**
+   * Deserializes the next argument from the serialized array starting from the current offset.
+   *
+   * @remarks
+   * If the deserialization failed, it returns an error message:
+   * "args doesn't know how to deserialize the given type."
+   *
+   * @returns a Result object:
+   * - Containing the next deserialized argument starting from the current offset
+   * - Containing an error message if the deserialization failed
+   *
+   */
+  next<T>(): Result<T> {
+    if (isBoolean<T>()) {
+      return this.nextBool() as Result<T>;
+    } else if (isInteger<T>()) {
+      if (isSigned<T>()) {
+        if (sizeof<T>() === sizeof<i16>()) {
+          return this.nextI16() as Result<T>;
+        } else if (sizeof<T>() === sizeof<i32>()) {
+          return this.nextI32() as Result<T>;
+        } else if (sizeof<T>() === sizeof<i64>()) {
+          return this.nextI64() as Result<T>;
+        }
+      } else {
+        if (sizeof<T>() === sizeof<u8>()) {
+          return this.nextU8() as Result<T>;
+        } else if (sizeof<T>() === sizeof<u16>()) {
+          return this.nextU16() as Result<T>;
+        } else if (sizeof<T>() === sizeof<u32>()) {
+          return this.nextU32() as Result<T>;
+        } else if (sizeof<T>() === sizeof<u64>()) {
+          return this.nextU64() as Result<T>;
+        }
+      }
+    } else if (isFloat<T>()) {
+      if (sizeof<T>() === sizeof<f32>()) {
+        return this.nextF32() as Result<T>;
+      } else {
+        return this.nextF64() as Result<T>;
+      }
+    } else if (isString<T>()) {
+      return this.nextString() as Result<T>;
+    } else if (isArray<T>()) {
+      if (idof<T>() === idof<Array<u8>>()) {
+        return this.nextFixedSizeArray<u8>() as Result<T>;
+      } else if (idof<T>() === idof<Array<string>>()) {
+        return this.nextStringArray() as Result<T>;
+      } else if (idof<T>() === idof<Array<i128>>()) {
+        return this.nextFixedSizeArray<i128>() as Result<T>;
+      } else if (idof<T>() === idof<Array<u128>>()) {
+        return this.nextFixedSizeArray<u128>() as Result<T>;
+      } else if (idof<T>() === idof<Array<u256>>()) {
+        return this.nextFixedSizeArray<u256>() as Result<T>;
+      } else if (idof<T>() === idof<Array<i32>>()) {
+        return this.nextFixedSizeArray<i32>() as Result<T>;
+      } else if (idof<T>() === idof<Array<u32>>()) {
+        return this.nextFixedSizeArray<u32>() as Result<T>;
+      } else if (idof<T>() === idof<Array<i64>>()) {
+        return this.nextFixedSizeArray<i64>() as Result<T>;
+      } else if (idof<T>() === idof<Array<u64>>()) {
+        return this.nextFixedSizeArray<u64>() as Result<T>;
+      } else if (idof<T>() === idof<Array<f32>>()) {
+        return this.nextFixedSizeArray<f32>() as Result<T>;
+      } else if (idof<T>() === idof<Array<f64>>()) {
+        return this.nextFixedSizeArray<f64>() as Result<T>;
+      } else if (idof<T>() === idof<Array<bool>>()) {
+        return this.nextFixedSizeArray<bool>() as Result<T>;
+      }
+      // TODO: Add support for Serializable's arrays
+    } else if (isManaged<T>()) {
+      if (idof<T>() === idof<string>()) {
+        return this.nextString() as Result<T>;
+      } else if (idof<T>() === idof<Uint8Array>()) {
+        return this.nextUint8Array() as Result<T>;
+      } else if (idof<T>() === idof<StaticArray<u8>>()) {
+        return this.nextBytes() as Result<T>;
+      } else if (idof<T>() === idof<i128>()) {
+        return this.nextI128() as Result<T>;
+      } else if (idof<T>() === idof<u128>()) {
+        return this.nextU128() as Result<T>;
+      } else if (idof<T>() === idof<u256>()) {
+        return this.nextU256() as Result<T>;
+      } else {
+        const object = instantiate<T>();
+        if (object instanceof Serializable) {
+          return this.nextSerializable<T>() as Result<T>;
+        }
+      }
+    }
+
+    ERROR("args doesn't know how to deserialize the given type.");
   }
 
   // Setter

--- a/packages/as-types/assembly/argument.ts
+++ b/packages/as-types/assembly/argument.ts
@@ -625,7 +625,6 @@ export class Args {
    * @remarks
    * If the deserialization failed, it returns an error message:
    * "args doesn't know how to deserialize the given type."
-   * For now, Arrays of Serializable objects are not supported. Please use `nextSerializableObjectArray` instead.
    *
    * @returns a Result object:
    * - Containing the next deserialized argument starting from the current offset
@@ -694,7 +693,6 @@ export class Args {
           return this.nextSerializableObjectArray<U>() as Result<T>;
         }
       }
-      // TODO: Add support for Serializable's arrays
     } else if (isManaged<T>()) {
       if (idof<T>() === idof<string>()) {
         return this.nextString() as Result<T>;

--- a/packages/as-types/assembly/argument.ts
+++ b/packages/as-types/assembly/argument.ts
@@ -620,14 +620,17 @@ export class Args {
   }
 
   /**
-   * Deserializes the next argument from the serialized array starting from the current offset.
+   * Deserializes the next object from the serialized array starting from the current offset.
    *
    * @remarks
    * If the deserialization failed, it returns an error message:
    * "args doesn't know how to deserialize the given type."
    *
+   * @typeParam T - The type of the object to deserialize
+   * @typeParam U - The type of the object to instantiate if the object is an array of serializable objects
+   *
    * @returns a Result object:
-   * - Containing the next deserialized argument starting from the current offset
+   * - Containing the next deserialized object starting from the current offset
    * - Containing an error message if the deserialization failed
    *
    */

--- a/packages/as-types/assembly/argument.ts
+++ b/packages/as-types/assembly/argument.ts
@@ -316,6 +316,30 @@ export class Args {
   }
 
   /**
+   * Deserializes an I128 from a serialized array starting from the current offset.
+   * 
+   * @remarks
+   * If the deserialization failed, it returns a Result containing 0 and an error message:
+   * "can't deserialize i128 from given argument: out of range".
+   * 
+   * @returns a Result object:
+   * - Containing the next deserialized I128 starting from the current offset
+   * - Containing 0 and an error message if the deserialization failed
+   * 
+   */
+  nextI128(): Result<i128> {
+    const size: i32 = 16;
+    if (this._offset + size > this.serialized.length) {
+      return new Result(
+        i128.Zero,
+        "can't deserialize i128 from given argument: out of range",
+      );
+    }
+    const value = ser.bytesToI128(this.getNextData(size));
+    return new Result(value);
+  }
+
+  /**
    * Deserializes an U64 from a serialized array starting from the current offset.
    *
    * @remarks
@@ -634,7 +658,9 @@ export class Args {
       this.serialized = this.serialized.concat(ser.f32ToBytes(<f32>arg));
     } else if (arg instanceof f64) {
       this.serialized = this.serialized.concat(ser.f64ToBytes(<f64>arg));
-    } else if (arg instanceof u128 || arg instanceof i128) {
+    } else if (arg instanceof i128) {
+      this.serialized = this.serialized.concat(ser.i128ToBytes(<i128>arg));
+    } else if (arg instanceof u128) {
       this.serialized = this.serialized.concat(ser.u128ToBytes(<u128>arg));
     } else if (arg instanceof u256) {
       this.serialized = this.serialized.concat(ser.u256ToBytes(<u256>arg));

--- a/packages/as-types/assembly/argument.ts
+++ b/packages/as-types/assembly/argument.ts
@@ -632,7 +632,7 @@ export class Args {
    * - Containing an error message if the deserialization failed
    *
    */
-  next<T>(): Result<T> {
+  next<T, U = void>(): Result<T> {
     if (isBoolean<T>()) {
       return this.nextBool() as Result<T>;
     } else if (isInteger<T>()) {
@@ -688,6 +688,11 @@ export class Args {
         return this.nextFixedSizeArray<f64>() as Result<T>;
       } else if (idof<T>() === idof<Array<bool>>()) {
         return this.nextFixedSizeArray<bool>() as Result<T>;
+      } else {
+        const object = instantiate<U>();
+        if (object instanceof Serializable) {
+          return this.nextSerializableObjectArray<U>() as Result<T>;
+        }
       }
       // TODO: Add support for Serializable's arrays
     } else if (isManaged<T>()) {

--- a/packages/as-types/assembly/argument.ts
+++ b/packages/as-types/assembly/argument.ts
@@ -625,6 +625,7 @@ export class Args {
    * @remarks
    * If the deserialization failed, it returns an error message:
    * "args doesn't know how to deserialize the given type."
+   * For now, Arrays of Serializable objects are not supported. Please use `nextSerializableObjectArray` instead.
    *
    * @returns a Result object:
    * - Containing the next deserialized argument starting from the current offset


### PR DESCRIPTION
This PR modifies a few things in Args:
- fixes a bug with `i128` serialization not working in `add<T>`
- add missing tests for `add<i128>`
- Add a `next<T>` which allows devs to deserialize the next element as the given type
- Add `next<T>` tests 