### PR TITLE
Add mustNext to args

### DIFF
--- a/packages/as-types/assembly/__tests__/argument.spec.ts
+++ b/packages/as-types/assembly/__tests__/argument.spec.ts
@@ -764,3 +764,34 @@ describe('Args next<T>', () => {
     expect(deserialized).toStrictEqual(arrayOfSerializable);
   });
 });
+
+describe('Args mustNext<T>', () => {
+  it('handles u8,stringArray,u256', () => {
+    const args = new Args(
+      new Args()
+        .add(123 as u8)
+        .add(['hello', 'world'])
+        .add(u256.Max)
+        .serialize(),
+    );
+
+    expect(args.mustNext<u8>('byte')).toBe(123);
+    expect(args.mustNext<Array<string>>('array')).toStrictEqual([
+      'hello',
+      'world',
+    ]);
+    expect(args.mustNext<u256>('u256')).toBe(u256.Max);
+  });
+
+  throws('fail to deserialize', () => {
+    const args = new Args(
+      new Args()
+        .add(123 as u8)
+        .add(['hello', 'world'])
+        .add(u256.Max)
+        .serialize(),
+    );
+
+    args.mustNext<Array<string>>('array');
+  });
+});

--- a/packages/as-types/assembly/__tests__/argument.spec.ts
+++ b/packages/as-types/assembly/__tests__/argument.spec.ts
@@ -783,7 +783,7 @@ describe('Args mustNext<T>', () => {
     expect(args.mustNext<u256>('u256')).toBe(u256.Max);
   });
 
-  throws('fail to deserialize', () => {
+  throws('fails to deserialize', () => {
     const args = new Args(
       new Args()
         .add(123 as u8)

--- a/packages/as-types/assembly/argument.ts
+++ b/packages/as-types/assembly/argument.ts
@@ -720,6 +720,22 @@ export class Args {
     ERROR("args doesn't know how to deserialize the given type.");
   }
 
+  /**
+   * Deserialize the next object from the serialized array starting from the current offset.
+   *
+   * @typeParam T - The type of the object to deserialize
+   * @typeParam U - The type of the object to instantiate if the object is an array of serializable objects
+   *
+   * @param field - The field name of the object to deserialize
+   *
+   * @returns the next deserialized object starting from the current offset
+   *
+   * @throws an error message if the deserialization failed: "Can't deserialize " + field
+   */
+  mustNext<T, U = void>(field: string): T {
+    return this.next<T, U>().expect(`Can't deserialize ${field}.`);
+  }
+
   // Setter
 
   /**


### PR DESCRIPTION
Adds a `mustNext` function that throws when an error occurs during deserialization
This function will help standardize error handling in Args deserialization